### PR TITLE
Update ExcludedMethods to IgnoredMethods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ Layout/HashAlignment:
   EnforcedColonStyle: table
 Metrics/BlockLength:
   Max: 35
-  ExcludedMethods: [ 'describe' ]
+  IgnoredMethods: [ 'describe' ]
 Metrics/MethodLength:
   Max: 25
 Metrics/AbcSize:


### PR DESCRIPTION
```
Warning: obsolete parameter `ExcludedMethods` (for `Metrics/BlockLength`) found in .rubocop.yml
`ExcludedMethods` has been renamed to `IgnoredMethods`
```