### PR TITLE
Issue with current v3 won't be fixed. So upgrade

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -43,6 +43,6 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: docker://github/super-linter:v3
+        uses: github/super-linter@v4
         env:
           DISABLE_ERRORS: true


### PR DESCRIPTION
https://github.com/github/super-linter/issues/2255

`[FATAL] Failed to view version file:[/action/lib/functions/linterVersions.txt]`
won't be fixed so I have to upgrade or remove the action